### PR TITLE
Made code repo a clickable link

### DIFF
--- a/src/materov2023/index.md
+++ b/src/materov2023/index.md
@@ -4,7 +4,7 @@
 
 named after the school sports team
 
-[Code Repo](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023)
+Code Repo: [https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023)
 
 ## Sposors
 

--- a/src/materov2023/index.md
+++ b/src/materov2023/index.md
@@ -4,8 +4,7 @@
 
 named after the school sports team
 
-Code Repo:
-https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023
+[Code Repo](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023)
 
 ## Sposors
 


### PR DESCRIPTION
The URL to the source on the 2023 page was not a clickable link. Made a slight tweak to fix this.